### PR TITLE
Update sqlserver.bicep to use the cheapest SKU by default

### DIFF
--- a/infra/core/database/sqlserver/sqlserver.bicep
+++ b/infra/core/database/sqlserver/sqlserver.bicep
@@ -28,6 +28,11 @@ resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
   resource database 'databases' = {
     name: databaseName
     location: location
+    sku: {
+      name: 'Basic'
+      tier: 'Basic'
+      capacity: 5
+    }
   }
 
   resource firewall 'firewallRules' = {


### PR DESCRIPTION
When deploying todo-csharp-sql-swa-func using `azd up`, SQL server instance is on general pricing at £200 a month. This should align with the other free/cheap SKUs used for other resources at £3.50 a month)